### PR TITLE
Reproduce shift down issue caused by navbar translucent

### DIFF
--- a/app/TestPage.ts
+++ b/app/TestPage.ts
@@ -1,0 +1,15 @@
+import { Page } from 'ui/page';
+
+export class TestPage extends Page {
+
+  public onLoaded() {
+    super.onLoaded();
+    
+    let navController = this.frame.ios.controller;
+    let navigationBar = navController ? navController.navigationBar : null;
+    if (navigationBar) {
+      // the view is being shifted down when translucent is set to false.
+      navigationBar.translucent = false;
+    }
+  }
+}

--- a/app/app.ts
+++ b/app/app.ts
@@ -6,8 +6,30 @@ purpose of the file is to pass control to the app’s first module.
 
 import "./bundle-config";
 import * as application from 'application';
+import { NavigationEntry } from 'ui/frame';
+import { ScrollView } from 'ui/scroll-view';
+import { TextView } from 'ui/text-view';
+import { TestPage } from './TestPage';
 
-application.run({ moduleName: 'app-root' });
+// Create page to be rendered
+const page: TestPage = new TestPage();
+page.actionBar.title = 'Test Action Bar'; 
+let pageContent;
+pageContent = new ScrollView();
+let textView = new TextView();
+textView.text = 'Test text view';
+pageContent.content = textView;
+page.content = pageContent;
+
+// Create navigation entry
+let navigationEntry: NavigationEntry;
+navigationEntry = {
+  create: (() => { return page; })
+};
+
+application.start(navigationEntry);
+
+// application.run({ moduleName: 'app-root' });
 
 /*
 Do not place any code after the application has been started as it will not


### PR DESCRIPTION
The shift down issue is happening when we set the navigation bar's translucent property to false.
Our project structure is render the page by adding the required controls accordingly.
on app.ts, will initiate a TestPage class, add action bar title, add the scroll view with text view inside.
On the TestPage class, will override the OnLoaded function, and inside the OnLoaded function will set the navigation bar's translucent to false, which will produce the shift down issue.

This is screenshot of using default translucent property:
![translucent_true](https://user-images.githubusercontent.com/39479284/40294986-4df33c2c-5d0a-11e8-82ec-4a1b5df58d7a.png)

This is screenshot of setting the nav bar translucent property to false:
![translucent_false](https://user-images.githubusercontent.com/39479284/40295000-5e69e1aa-5d0a-11e8-81b2-bd4308ebe347.png)

Kindly help to check.
Thanks!