### PR TITLE
Test using application.run for navigation entry

### DIFF
--- a/app/TestPage.ts
+++ b/app/TestPage.ts
@@ -1,0 +1,18 @@
+import { Page } from 'ui/page';
+
+export class TestPage extends Page {
+
+  public onLoaded() {
+    super.onLoaded();
+    
+    // using application.run(navigation_entry) will caused the this.frame to be undefined
+    /*
+    let navController = this.frame.ios.controller;
+    let navigationBar = navController ? navController.navigationBar : null;
+    if (navigationBar) {
+      // the view is being shifted down when translucent is set to false.
+      navigationBar.translucent = false;
+    }
+    */
+  }
+}

--- a/app/app.ts
+++ b/app/app.ts
@@ -6,8 +6,30 @@ purpose of the file is to pass control to the app’s first module.
 
 import "./bundle-config";
 import * as application from 'application';
+import { NavigationEntry } from 'ui/frame';
+import { ScrollView } from 'ui/scroll-view';
+import { TextView } from 'ui/text-view';
+import { TestPage } from './TestPage';
 
-application.run({ moduleName: 'app-root' });
+// Create page to be rendered
+const page: TestPage = new TestPage();
+page.actionBar.title = 'Test Action Bar'; 
+let pageContent;
+pageContent = new ScrollView();
+let textView = new TextView();
+textView.text = 'Test text view';
+pageContent.content = textView;
+page.content = pageContent;
+
+// Create navigation entry
+let navigationEntry: NavigationEntry;
+navigationEntry = {
+  create: (() => { return page; })
+};
+
+application.run(navigationEntry);
+
+// application.run({ moduleName: 'app-root' });
 
 /*
 Do not place any code after the application has been started as it will not


### PR DESCRIPTION
Our project does not have physical xml page file, so we can only stick to the original parameter using the NavigationEntry.
When we tried to change from application.start(navigationEntry) to application.run(navigationEntry), we found several issues as below:

- this.frame inside a Page class is undefined
- actionbar is not displaying
- topmost is undefined

This is the screenshot of actionbar not displaying:
![using_run_missing_actionbar](https://user-images.githubusercontent.com/39479284/40295171-fcc69794-5d0a-11e8-9f29-4a7e17377984.png)


Kindly help to check and advise us on how can we proceed to use application.run.
Thanks!